### PR TITLE
[CLUSTER]: Resolve Numpy Version Discrepancy Bug on Line 1297

### DIFF
--- a/berry/_subroutines/clustering_libs.py
+++ b/berry/_subroutines/clustering_libs.py
@@ -7,6 +7,9 @@ to determine the connectivity of points in the k-space, and then uses unsupervis
 to classify the points into bands.
 
 TODO:
+  - Implement functionality to allow the algorithm to save intermediate results.
+    Also, consider adding the ability to resume the algorithm or select the best result,
+    which may differ from the last one.
   - Implement the algorithm to resolve forbidden paths
   - Implement the algorithm to address points connected to more than one band
 """
@@ -1294,7 +1297,9 @@ class MATERIAL:
             # For each possible degenerate point have to exist a pair
             for k_, k_deg_, bn_, bns_deg_ in k_basis_rotation[i+1:]:
                 # Comparison between each possible degenerate point.
-                if k != k_ or not np.all(k_deg == k_deg_):
+                k_deg = np.array(k_deg)
+                k_deg_ = np.array(k_deg_)
+                if k != k_ or k_deg.shape != k_deg_.shape or not np.all(k_deg == k_deg_):
                     # The k_ point is not the k's pair
                     continue
                 if not np.all([np.all(np.isin(bns, bns_deg_[j])) for j, bns in enumerate(bns_deg)]):


### PR DESCRIPTION
This commit addresses a bug found on line 1297, which did not manifest in the development environment. It was determined that the bug remained unnoticed due to a disparity in the numpy version. In the Python development environment where the code was originally tested, the numpy version was 1.23.5. However, in a newly installed environment with all the necessary dependencies, the numpy version was updated to 1.26.3. Ideally, the specified numpy version to be installed should be 1.23.5, as indicated in the requirements file.

Consequently, the bug surfaced when executing the code on a clean installation of a Python environment with the latest version of numpy, resulting in a shape mismatch error.

It is challenging to pinpoint the main differences between numpy versions 1.26.3 and 1.23.5 for the functions 'where,' 'unique,' and 'split.' These functions appear to function identically in the program, and their behavior aligns with the documentation. However, in this specific part of the algorithm, there is a slight variation in the returned arrays. Unfortunately, the exact point where the arrays start to differ could not be identified.

To circumvent the issue with the latest numpy version (1.26.3), a new condition has been added to verify the array shapes before comparison. It's important to note that this adjustment does not impact the final result of the program and is intended to accommodate the differences in the 1.26.3 version of numpy, which appears to be the default version installed when setting up the berry suite of programs.